### PR TITLE
Prevent duplicate farewell messages on ticket closure

### DIFF
--- a/backend/src/controllers/TicketController.ts
+++ b/backend/src/controllers/TicketController.ts
@@ -154,14 +154,18 @@ export const update = async (
 
   const ticketData: TicketData = { ...req.body, tenantId };
 
-  const { ticket } = await UpdateTicketService({
+  const { ticket, oldStatus } = await UpdateTicketService({
     ticketData,
     ticketId,
     isTransference,
     userIdRequest
   });
 
-  if (ticket.status === "closed") {
+  if (
+    ticket.status === "closed" &&
+    oldStatus !== "closed" &&
+    !ticket.isFarewellMessage
+  ) {
     const whatsapp = await Whatsapp.findOne({
       where: { id: ticket.whatsappId, tenantId }
     });


### PR DESCRIPTION
## Summary
- capture `oldStatus` from ticket update
- avoid sending farewell message again if ticket already closed or message sent

## Testing
- `npm test` *(fails: Cannot connect to test database, ERROR)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dd77d80483239479ea6aa2653829